### PR TITLE
Adding Operator Ids to the PhysicalPlanProperties

### DIFF
--- a/datafusion/core/src/datasource/continuous/kafka_source.rs
+++ b/datafusion/core/src/datasource/continuous/kafka_source.rs
@@ -42,6 +42,7 @@ impl KafkaSource {
     pub async fn create_physical_plan(
         &self,
         projection: Option<&Vec<usize>>,
+        operator_id: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let projected_schema = match projection {
             Some(p) => {
@@ -66,7 +67,7 @@ impl KafkaSource {
             projection,
             projected_schema,
             true,
-            None,
+            operator_id,
         )?))
     }
 }
@@ -92,7 +93,7 @@ impl TableProvider for KafkaSource {
         _filters: &[Expr],
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        return self.create_physical_plan(projection).await;
+        return self.create_physical_plan(projection, _limit).await;
     }
 }
 

--- a/datafusion/core/src/physical_optimizer/coalesce_before_streaming_window_aggregate.rs
+++ b/datafusion/core/src/physical_optimizer/coalesce_before_streaming_window_aggregate.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use datafusion_physical_expr::Partitioning;
 use datafusion_physical_plan::repartition::RepartitionExec;
-use datafusion_physical_plan::ExecutionPlanProperties;
+use datafusion_physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 
 use crate::common::tree_node::{Transformed, TransformedResult, TreeNode};
 use crate::error::Result;
@@ -52,6 +52,7 @@ impl PhysicalOptimizerRule for CoaslesceBeforeStreamingAggregate {
                         coalesce_exec.clone(),
                         input.schema(),
                         streaming_aggr_exec.window_type.clone(),
+                        streaming_aggr_exec.properties().operator_id,
                     )?,
                 )))
             } else {
@@ -139,6 +140,7 @@ pub(crate) mod tests {
             source,
             Arc::clone(&schema),
             FranzStreamingWindowType::Tumbling(Duration::from_millis(5000)),
+            Some(1),
         )
         .unwrap();
 
@@ -172,6 +174,7 @@ pub(crate) mod tests {
             source,
             Arc::clone(&schema),
             FranzStreamingWindowType::Tumbling(Duration::from_millis(5000)),
+            Some(1),
         )
         .unwrap();
 

--- a/datafusion/physical-plan/src/lib.rs
+++ b/datafusion/physical-plan/src/lib.rs
@@ -581,6 +581,8 @@ pub struct PlanProperties {
     pub partitioning: Partitioning,
     /// See [ExecutionPlanProperties::execution_mode]
     pub execution_mode: ExecutionMode,
+    /// See [ExecutionPlanProperties::operator_id]
+    pub operator_id: Option<usize>,
     /// See [ExecutionPlanProperties::output_ordering]
     output_ordering: Option<LexOrdering>,
 }
@@ -598,6 +600,7 @@ impl PlanProperties {
             eq_properties,
             partitioning,
             execution_mode,
+            operator_id: None,
             output_ordering,
         }
     }
@@ -620,6 +623,12 @@ impl PlanProperties {
         // make sure to overwrite it:
         self.output_ordering = eq_properties.output_ordering();
         self.eq_properties = eq_properties;
+        self
+    }
+
+    pub fn with_operator_id(mut self, operator_id: Option<usize>) -> Self {
+        // Operator id for the physical plan
+        self.operator_id = operator_id;
         self
     }
 

--- a/datafusion/physical-plan/src/streaming.rs
+++ b/datafusion/physical-plan/src/streaming.rs
@@ -97,6 +97,7 @@ impl StreamingTableExec {
             &projected_output_ordering,
             &partitions,
             infinite,
+            limit, //WARNING: limit has been overloaded to pass through operator id.
         );
         Ok(Self {
             partitions,
@@ -144,6 +145,7 @@ impl StreamingTableExec {
         orderings: &[LexOrdering],
         partitions: &[Arc<dyn PartitionStream>],
         is_infinite: bool,
+        operator_id: Option<usize>,
     ) -> PlanProperties {
         // Calculate equivalence properties:
         let eq_properties = EquivalenceProperties::new_with_orderings(schema, orderings);
@@ -159,6 +161,7 @@ impl StreamingTableExec {
         };
 
         PlanProperties::new(eq_properties, output_partitioning, mode)
+            .with_operator_id(operator_id)
     }
 }
 


### PR DESCRIPTION
This PR:

1. Adds operator_id (Option<usize>) to the PhysicalPlanProperties
2. For now we are only adding the ids to `StreamingWindowExec` and `StreamingTableExec`